### PR TITLE
fix: Invalid imports. Update imports on validator.ts

### DIFF
--- a/src/validators.ts
+++ b/src/validators.ts
@@ -1,4 +1,4 @@
-import { Token } from "aws-cdk-lib/core";
+import { Token } from "aws-cdk-lib";
 
 export class Validators {
   /**


### PR DESCRIPTION
`aws-cdk-lib` does not have a` /core` defined export. Importing `Token `from `aws-cdk-lib/core` will result in this error: 

`Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './lib/core' is not defined by "exports" in /[installation_path]`

Token is now directly exported by `aws-cdk-lib`

# Fixes
- ERR_PACKAGE_PATH_NOT_EXPORTED